### PR TITLE
Adjust the namespace to support composer auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ public function cards()
 {
     return [
         // ...
-        new \Vink\CacheCard\CacheCard(),
+        new \Vink\NovaCacheCard\CacheCard(),
     ];
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Vink\\CacheCard\\": "src/"
+            "Vink\\NovaCacheCard\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Vink\\CacheCard\\CardServiceProvider"
+                "Vink\\NovaCacheCard\\CardServiceProvider"
             ]
         }
     },

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,6 @@ use Illuminate\Support\Facades\Route;
 | as many additional routes to this file as your card may require.
 |
 */
-Route::post('/flush', 'Vink\CacheCard\Http\Controllers\CacheCardController@flush');
-Route::post('/cache', 'Vink\CacheCard\Http\Controllers\CacheCardController@forget');
-Route::get('/cache', 'Vink\CacheCard\Http\Controllers\CacheCardController@get');
+Route::post('/flush', 'Vink\NovaCacheCard\Http\Controllers\CacheCardController@flush');
+Route::post('/cache', 'Vink\NovaCacheCard\Http\Controllers\CacheCardController@forget');
+Route::get('/cache', 'Vink\NovaCacheCard\Http\Controllers\CacheCardController@get');

--- a/src/CacheCard.php
+++ b/src/CacheCard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vink\CacheCard;
+namespace Vink\NovaCacheCard;
 
 use Laravel\Nova\Card;
 use Illuminate\Support\Facades\Storage;

--- a/src/CacheHelpers.php
+++ b/src/CacheHelpers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vink\CacheCard;
+namespace Vink\NovaCacheCard;
 
 class CacheHelpers {
     /**

--- a/src/CardServiceProvider.php
+++ b/src/CardServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vink\CacheCard;
+namespace Vink\NovaCacheCard;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Events\ServingNova;

--- a/src/Http/Controllers/CacheCardController.php
+++ b/src/Http/Controllers/CacheCardController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vink\CacheCard\Http\Controllers;
+namespace Vink\NovaCacheCard\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;

--- a/src/Http/Controllers/CacheCardController.php
+++ b/src/Http/Controllers/CacheCardController.php
@@ -5,7 +5,7 @@ namespace Vink\NovaCacheCard\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Cache;
-use Vink\CacheCard\CacheHelpers;
+use Vink\NovaCacheCard\CacheHelpers;
 
 class CacheCardController extends Controller
 {


### PR DESCRIPTION
Tweak the code namespace to match up with the root directory name.

Fixes #6.

Make sure you run `composer dump-autoload`, update your `NovaServiceProvider.php` to reflect the new namespace, and re-cache your routes.